### PR TITLE
fix: loaders download script not working on non-FHS distros

### DIFF
--- a/web-build/ioncube/download-loaders.sh
+++ b/web-build/ioncube/download-loaders.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #ddev-generated
 set -e
 


### PR DESCRIPTION
## The Issue
I tried installing this extension on NixOS and I got an error about bash missing. Symlinking /bin/sh to /bin/bash is a temporary solution.
## How This PR Solves The Issue
It uses env to call bash, like [modify-dockerfile.sh](https://github.com/ddev/ddev-ioncube/blob/5b7a9f471700375e9a9c19b7a42eebfb7a0f3fd9/web-build/ioncube/modify-dockerfile.sh#L1)
