### PR TITLE
feat: add support for PHP 8.4

### DIFF
--- a/tests/test.bats
+++ b/tests/test.bats
@@ -48,6 +48,16 @@ health_checks() {
   assert_success
   assert_output --partial 'ionCube Loader'
   assert_output --partial 'ionCube PHP Loader'
+
+  # check php8.4 as well
+  run ddev exec php8.4 -v
+  assert_success
+  assert_output --partial 'with the ionCube PHP Loader'
+
+  run ddev exec php8.4 -m
+  assert_success
+  assert_output --partial 'ionCube Loader'
+  assert_output --partial 'ionCube PHP Loader'
 }
 
 teardown() {

--- a/web-build/ioncube/modify-dockerfile.sh
+++ b/web-build/ioncube/modify-dockerfile.sh
@@ -3,7 +3,7 @@
 
 add_directives() {
 	local FILE_PATH="$1"
-	local PHP_VERSIONS=("5.6" "7.0" "7.1" "7.2" "7.3" "7.4" "8.1" "8.2" "8.3")
+	local PHP_VERSIONS=("5.6" "7.0" "7.1" "7.2" "7.3" "7.4" "8.1" "8.2" "8.3" "8.4")
 
 	cat <<EOF >>"$FILE_PATH"
 # BEGIN IonCube Install
@@ -14,7 +14,11 @@ RUN rm -rf /etc/php/*/mods-available/ioncube.ini /etc/php/*/mods-available/00-io
 EOF
 
 	for VERSION in "${PHP_VERSIONS[@]}"; do
-		printf "RUN printf \"zend_extension = /etc/php/ioncube/ioncube_loader_lin_%s.so%s; priority=0\" > /etc/php/%s/mods-available/00-ioncube.ini\n" "$VERSION" '\n' "$VERSION" >>"$FILE_PATH"
+		printf "RUN printf \"zend_extension = /etc/php/ioncube/ioncube_loader_lin_%s.so%s; priority=0%s\" > /etc/php/%s/mods-available/00-ioncube.ini\n" "$VERSION" '\n' '\n' "$VERSION" >>"$FILE_PATH"
+		if [[ "$VERSION" == "8.4" ]]; then
+			# PHP Warning:  JIT is incompatible with third party extensions that setup user opcode handlers. JIT disabled. in Unknown on line 0
+			printf "RUN printf \"# disable jit for ioncube%sopcache.jit=disable%s\" >> /etc/php/%s/mods-available/opcache.ini\n" '\n' '\n' "$VERSION" >>"$FILE_PATH"
+		fi
 	done
 
 	cat <<EOF >>"$FILE_PATH"


### PR DESCRIPTION
## The Issue

ionCube has support for PHP 8.4

## How This PR Solves The Issue

Adds it.

## Manual Testing Instructions

```bash
ddev add-on get https://github.com/ddev/ddev-ioncube/tarball/20250411_stasadev_php8.4
ddev restart
```

## Automated Testing Overview

<!-- Please describe the tests introduced by this PR, or explain why no tests are needed. -->

## Release/Deployment Notes

<!-- Does this affect anything else or have ramifications for other code? Does anything have to be done on deployment? -->
