### PR TITLE
fix: use correct URL for arm64, fixes #67

### DIFF
--- a/web-build/ioncube/download-loaders.sh
+++ b/web-build/ioncube/download-loaders.sh
@@ -4,7 +4,7 @@ set -e
 
 ARCH="$(uname -m)"
 
-if [ "$ARCH" = "aarch64" ]; then
+if [ "$ARCH" = "arm64" ]; then
 	ARCH="aarch64"
 elif [ "$ARCH" = "x86_64" ]; then
 	ARCH="x86-64"


### PR DESCRIPTION
## The Issue

- #67

I see that the correct condition for `arm64` was changed here (by mistake?):

- https://github.com/ddev/ddev-ioncube/pull/54

## How This PR Solves The Issue

Uses the correct condition.

## Manual Testing Instructions

Using macOS arm64:

```bash
ddev add-on get https://github.com/ddev/ddev-ioncube/tarball/20250423_stasadev_arm64
ddev restart
```

## Automated Testing Overview

<!-- Please describe the tests introduced by this PR, or explain why no tests are needed. -->

## Release/Deployment Notes

<!-- Does this affect anything else or have ramifications for other code? Does anything have to be done on deployment? -->
