### PR TITLE
feat: add support for PHP 8.5, fixes #71

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ This add-on integrates ionCube Loaders into your [DDEV](https://ddev.com/) proje
 
 ## Features
 
-- ✅ ionCube Loaders for PHP 5.6–8.5, except PHP 8.0 ([not supported by ionCube](https://blog.ioncube.com/2022/08/12/ioncube-php-8-1-support-faq-were-almost-ready/))
+- ✅ ionCube Loaders for PHP 5.6-8.5, except PHP 8.0 ([not supported by ionCube](https://blog.ioncube.com/2022/08/12/ioncube-php-8-1-support-faq-were-almost-ready/))
 - ✅ Multi-arch support (Will detect your system architecture and install the correct loader version)
 - ✅ Plays nice with your existing DDEV configuration
 - ✅ Works with other web container customizations
@@ -25,6 +25,12 @@ This add-on integrates ionCube Loaders into your [DDEV](https://ddev.com/) proje
 ddev add-on get ddev/ddev-ioncube
 ddev restart
 ```
+
+> [!NOTE]
+> The latest ionCube Loaders are always pulled when you upgrade DDEV. To pull the latest loaders manually, run:
+> ```bash
+> ddev restart --no-cache
+> ```
 
 ## Configuration
 

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ This add-on integrates ionCube Loaders into your [DDEV](https://ddev.com/) proje
 
 ## Features
 
-- ✅ ionCube Loaders for all supported PHP versions
+- ✅ ionCube Loaders for PHP 5.6–8.5, except PHP 8.0 ([not supported by ionCube](https://blog.ioncube.com/2022/08/12/ioncube-php-8-1-support-faq-were-almost-ready/))
 - ✅ Multi-arch support (Will detect your system architecture and install the correct loader version)
 - ✅ Plays nice with your existing DDEV configuration
 - ✅ Works with other web container customizations

--- a/tests/test.bats
+++ b/tests/test.bats
@@ -39,25 +39,27 @@ setup() {
 }
 
 health_checks() {
-  # default php is 8.3
-  run ddev php -v
-  assert_success
-  assert_output --partial 'with the ionCube PHP Loader'
+  # check that loader .so and ini are present for all supported PHP versions
+  for VERSION in 8.5 8.4 8.3 8.2 8.1 7.4 7.3 7.2 7.1 7.0 5.6; do
+    run ddev exec test -f /etc/php/ioncube/ioncube_loader_lin_${VERSION}.so
+    assert_success
 
-  run ddev php -m
-  assert_success
-  assert_output --partial 'ionCube Loader'
-  assert_output --partial 'ionCube PHP Loader'
+    run ddev exec test -f /etc/php/${VERSION}/mods-available/00-ioncube.ini
+    assert_success
+  done
 
-  # check php8.4 as well
-  run ddev exec php8.4 -v
-  assert_success
-  assert_output --partial 'with the ionCube PHP Loader'
+  # check that the loader actually works for PHP versions bundled in ddev-webserver
+  for VERSION in 8.5 8.4 8.3 8.2; do
+    run ddev exec php${VERSION} -v
+    assert_success
+    assert_output --partial 'with the ionCube PHP Loader'
+    refute_output --partial 'PHP Warning:'
 
-  run ddev exec php8.4 -m
-  assert_success
-  assert_output --partial 'ionCube Loader'
-  assert_output --partial 'ionCube PHP Loader'
+    run ddev exec php${VERSION} -m
+    assert_success
+    assert_output --partial 'ionCube Loader'
+    assert_output --partial 'ionCube PHP Loader'
+  done
 }
 
 teardown() {

--- a/web-build/ioncube/modify-dockerfile.sh
+++ b/web-build/ioncube/modify-dockerfile.sh
@@ -2,49 +2,47 @@
 #ddev-generated
 
 add_directives() {
-    local FILE_PATH="$1"
-    local PHP_VERSIONS=("5.6" "7.0" "7.1" "7.2" "7.3" "7.4" "8.1" "8.2" "8.3" "8.4")
+ local FILE_PATH="$1"
 
-    cat <<EOF >>"$FILE_PATH"
+ cat <<'ENDDOCKERFILE' >>"$FILE_PATH"
 #ddev-generated
+#ddev-silent-no-warn
 ARG TARGETARCH
 
 RUN <<ENDIONCUBE
-    set -eu -o pipefail
-    ARCH="\${TARGETARCH}"
-    if [ "\$ARCH" = "arm64" ]; then
-        ARCH="aarch64"
-    elif [ "\$ARCH" = "amd64" ]; then
-        ARCH="x86-64"
+  set -eu -o pipefail
+  ARCH="${TARGETARCH}"
+  if [ "$ARCH" = "arm64" ]; then
+    ARCH="aarch64"
+  elif [ "$ARCH" = "amd64" ]; then
+    ARCH="x86-64"
+  fi
+  curl -L -o /tmp/ioncube_loaders.tar.gz https://downloads.ioncube.com/loader_downloads/ioncube_loaders_lin_${ARCH}.tar.gz
+  mkdir -p /etc/php/ioncube
+  tar -zxvf /tmp/ioncube_loaders.tar.gz -C /etc/php/ioncube --strip-components=1
+  rm -f /tmp/ioncube_loaders.tar.gz
+  chown -R root:root /etc/php/ioncube
+  rm -rf /etc/php/*/mods-available/ioncube.ini /etc/php/*/mods-available/00-ioncube.ini
+  for SO_FILE in /etc/php/ioncube/ioncube_loader_lin_*.so; do
+    VERSION=$(basename "$SO_FILE" .so | sed 's/ioncube_loader_lin_//')
+    if [ -d "/etc/php/$VERSION" ]; then
+      printf "zend_extension = /etc/php/ioncube/ioncube_loader_lin_%s.so\n; priority=0\n" "$VERSION" > "/etc/php/$VERSION/mods-available/00-ioncube.ini"
+      # PHP Warning: JIT is incompatible with third party extensions that setup user opcode handlers. JIT disabled. in Unknown on line 0
+      if [ "$VERSION" = "8.4" ]; then
+        printf "# disable jit for ioncube\nopcache.jit=disable\n" >> "/etc/php/$VERSION/mods-available/opcache.ini"
+      fi
     fi
-    curl -L -o /tmp/ioncube_loaders.tar.gz https://downloads.ioncube.com/loader_downloads/ioncube_loaders_lin_\$ARCH.tar.gz
-    mkdir -p /etc/php/ioncube
-    tar -zxvf /tmp/ioncube_loaders.tar.gz -C /etc/php/ioncube --strip-components=1
-    rm -f /tmp/ioncube_loaders.tar.gz
-    chown -R root:root /etc/php/ioncube
-    rm -rf /etc/php/*/mods-available/ioncube.ini /etc/php/*/mods-available/00-ioncube.ini
+  done
+  phpenmod 00-ioncube
 ENDIONCUBE
-
-EOF
-
-    for VERSION in "${PHP_VERSIONS[@]}"; do
-        printf "RUN printf \"zend_extension = /etc/php/ioncube/ioncube_loader_lin_%s.so%s; priority=0%s\" > /etc/php/%s/mods-available/00-ioncube.ini\n" "$VERSION" '\n' '\n' "$VERSION" >>"$FILE_PATH"
-        if [[ "$VERSION" == "8.4" ]]; then
-            # PHP Warning:  JIT is incompatible with third party extensions that setup user opcode handlers. JIT disabled. in Unknown on line 0
-            printf "RUN printf \"# disable jit for ioncube%sopcache.jit=disable%s\" >> /etc/php/%s/mods-available/opcache.ini\n" '\n' '\n' "$VERSION" >>"$FILE_PATH"
-        fi
-    done
-
-    cat <<EOF >>"$FILE_PATH"
-RUN phpenmod 00-ioncube
-EOF
+ENDDOCKERFILE
 }
 
 # Define the file path
 DOCKERFILE="web-build/Dockerfile.ioncube"
 
 if [ -e "$DOCKERFILE" ]; then
-    rm -f "$DOCKERFILE" >/dev/null
+  rm -f "$DOCKERFILE" >/dev/null
 fi
 
 add_directives "$DOCKERFILE"


### PR DESCRIPTION
## The Issue

- Fixes #71

Adds PHP 8.5 support and clarifies which PHP versions are supported.

## How This PR Solves The Issue

- Replaced the hardcoded PHP version array in `modify-dockerfile.sh` with a dynamic loop over installed `.so` files, so new PHP versions are picked up automatically without code changes
- Expanded `tests/test.bats` health checks to verify loader presence for all supported versions (5.6–8.5, skipping 8.0) and functional checks for versions bundled in ddev-webserver
- Updated README to list the exact supported range (PHP 5.6–8.5, except 8.0) with a link to the official ionCube statement on why 8.0 is unsupported

## Manual Testing Instructions

```bash
ddev add-on get https://github.com/ddev/ddev-ioncube/tarball/refs/pull/72/head
ddev restart
ddev php -v
```

## Automated Testing Overview

Expanded health checks now iterate over all supported PHP versions to assert both the `.so` loader file and the `00-ioncube.ini` config are present, and run functional `php -v` / `php -m` checks for versions available in ddev-webserver (8.2–8.5).

## Release/Deployment Notes

The dynamic loop in `modify-dockerfile.sh` means future PHP versions will be supported automatically once ionCube ships a loader for them, with no add-on code changes required.